### PR TITLE
Improvements and Fixes to TaxDocument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-
 # Abound Client SDK
 
 The Abound Client SDK provides convenient access to embeddable UI components powered by [Abound's API](https://docs.withabound.com/) .
 
-## Requirements 
+## Requirements
 
-- iOS 13.
-- Swift 5.5+
-- Xcode 13.0+
+-   iOS 13.
+-   Swift 5.5+
+-   Xcode 13.0+
 
 ## Installation
 
@@ -15,7 +14,7 @@ The preferred way of installing the Abound iOS Client SDK is via the [Swift Pack
 
 1. In Xcode, open your project and navigate to **File** → **Swift Packages** → **Add Package Dependency...**
 2. Paste the repository URL (`https://github.com/withabound/abound-ios-client-sdk/`) and click **Next**.
-3. For **Rules**, select **Branch** (with branch set to `master`).
+3. For **Rules**, select **Branch** (with branch set to `main`).
 4. Click **Finish**.
 5. Open the Project settings, add **SwiftUI.framework** to the **Linked Frameworks and Libraries**, set **Status** to **Optional**.
 
@@ -26,7 +25,9 @@ The preferred way of installing the Abound iOS Client SDK is via the [Swift Pack
 You can start to integrate the Abound Client SDK library into your solution as soon as you [create an account with Abound][developer-dashboard-signup], [obtain your API keys][developer-dashboard-keys], and create an access token.
 
 ### Usage
+
 First we need to import the Abound namespace
+
 ```swift
 import Abound
 ```
@@ -34,17 +35,17 @@ import Abound
 The Abound client must be configured with an `accessToken` requested from the [Abound API](https://docs.withabound.com/reference/createaccesstoken).
 
 ```swift
-Abound.accessToken = "accessToken_testeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBfaWQiOiJhcHBJZF90ZXN0NDhlN2VhYTMxNzVhNjYzNTRlMDA2MjY1NDJkMiIsImNyZWF0ZWRfdGltZXN0YW1wIjoxNjU1MDk2NDAwMDAwLCJlbnZpcm9ubWVudCI6Imh0dHBzOi8vc2FuZGJveC1hcGkud2l0aGFib3VuZC5jb20vdjIiLCJleHBpcmF0aW9uX3RpbWVzdGFtcCI6MzI1MDM3MDE2MDAwMDAsInN0YXR1cyI6IkFjdGl2ZSIsInVzZXJfaWQiOiJ1c2VySWRfdGVzdDI0YjA1ZDc2MWZmNThiNTkzMWJkMDc3NzhjNjdiNGU4MThlNCIsImlhdCI6MTY1NTEzMDMxM30.dOUIyxTRV0QDmrFiy-GoyhKc8qru3pymIcPS5cGTaNk"
+Abound.accessToken = "accessToken_sampleeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTY5ODczNTcsImV4cCI6MTY5Njk4NzY1NywiYXVkIjoiYXBwSWRfc2FtcGxlcU5oVmNkWVFZVSIsImlzcyI6Imh0dHBzOi8vc2FuZGJveC1hcGkud2l0aGFib3VuZC5jb20vdjQiLCJzdWIiOiJ1c2VySWRfc2FtcGxlWEdNRm5oT3BlUiJ9.-NrPVQvsnM8vJouyuP5yeFGlYb1xGgR-gS3v87p5BQk"
 ```
 
-Then we can show the [Tax Profile](https://docs.withabound.com/docs/adding-a-tax-profile-drop-in-to-your-app)
+Then we can show the [Tax Profile](https://docs.withabound.com/docs/tax-profile-drop-in-w-9-substitute)
 
 ```swift
 TaxProfile()
 ```
 
-we can also add Custom Text Content for Tax Profile , for specific states.
-Currently you can set the values for 
+We can also add Custom Text Content for Tax Profile, for specific states.
+Currently you can set the values for
 
 submitButton (Defaults to 'Submit')
 loadingButton (Defaults to 'Loading...')
@@ -60,26 +61,13 @@ errorMessage (Defaults to 'Invalid')
     );
 ```
 
-or a [Tax  Document](https://docs.withabound.com/docs/adding-a-tax-documents-drop-in-to-your-app)
-
-### Debug Mode
-
-You can pass a parameter called debug, that allows to test specific states when passing an EIN/TIN value
-
-| Status     | Description                                                       | Testing Value |
-|------------|-------------------------------------------------------------------|---------------|
-| unverified | Unverified                                                        | 999999999     |
-| mismatch   | TIN and name do not match.                                        | 333333333     |
-| error      | This is a system-failure error and should rarely, if ever, occur. | 111111111     |
-| lockedOut  | Verification for user locked for 24-hours.                        | 555555555     |
-
-        
+or a [Tax Document](https://docs.withabound.com/docs/tax-documents-drop-in)
 
 ```swift
 TaxDocuments(year: '2022')
 ```
 
-Some properties for the design can be changed used [custom themes](https://docs.withabound.com/docs/custom-theming-for-drop-in-components), that can be passed as optional parameters for the TaxDocument / TaxProfile
+Some properties for the design can be changed used [custom themes](https://docs.withabound.com/docs/white-label-theming), that can be passed as optional parameters for the TaxDocument / TaxProfile
 
 ```swift
 AboundTheme(
@@ -89,7 +77,6 @@ AboundTheme(
     button: AboundThemeButton(colorActiveBackground: "#655BEF")
 )
 ```
-
 
 [docs]: https://docs.withabound.com
 [developer-dashboard]: https://dashboard.withabound.com

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ errorMessage (Defaults to 'Invalid')
 
 or a [Tax  Document](https://docs.withabound.com/docs/adding-a-tax-documents-drop-in-to-your-app)
 
+### Debug Mode
+
+You can pass a parameter called debug, that allows to test specific states when passing an EIN/TIN value
+
+| Status     | Description                                                       | Testing Value |
+|------------|-------------------------------------------------------------------|---------------|
+| unverified | Unverified                                                        | 999999999     |
+| mismatch   | TIN and name do not match.                                        | 333333333     |
+| error      | This is a system-failure error and should rarely, if ever, occur. | 111111111     |
+| lockedOut  | Verification for user locked for 24-hours.                        | 555555555     |
+
+        
+
 ```swift
 TaxDocuments(year: '2022')
 ```

--- a/Sources/Abound/HTMLContent.swift
+++ b/Sources/Abound/HTMLContent.swift
@@ -26,7 +26,7 @@ var taxProfileHTML = """
         window.webkit.messageHandlers.onSuccess.postMessage("");
       }
       function onError(error) {
-        window.webkit.messageHandlers.onError.postMessage(error);
+        window.webkit.messageHandlers.onError.postMessage(error.toString());
       }
     </script>
     <script type="module">

--- a/Sources/Abound/HTMLContent.swift
+++ b/Sources/Abound/HTMLContent.swift
@@ -31,6 +31,8 @@ var taxProfileHTML = """
     </script>
     <script type="module">
       import Abound from "https://js.withabound.com/latest/abound-client-sdk.js";
+      // debug mode
+      %@
       // Access Token
       const abound = new Abound({
         accessToken: "%@",
@@ -39,10 +41,37 @@ var taxProfileHTML = """
       %@
       // Custom Content
       %@
+      function onSuccessOrError (){
+                      if(debugMode){
+                          const eins = document.getElementsByName("ein")
+                          if(eins.length>0){
+                              const ein = eins[0].value.replace("-","");
+                              switch(ein){
+                                  case "999999999":
+                                      onError("unverified");
+                                  break;
+                                  case "333333333":
+                                      onError("mismatch");
+                                  break;
+                                  case "111111111":
+                                      onError("error");
+                                  break;
+                                  case "555555555":
+                                      onError("lockedOut");
+                                  break;
+                                  default:
+                                      onSuccess();
+                              }
+                          }
+                      }else{
+                          onSuccess();
+                      }
+                    
+                  }
       abound.renderTaxProfile({
         targetId: "abound-ui-wrapper",
         theme: customTheme,
-        onSubmitSuccess: onSuccess,
+        onSubmitSuccess: onSuccessOrError,
         onSubmitError: onError,
         content: customContent,
       });
@@ -77,6 +106,8 @@ var taxDocumentHTML = """
     </script>
         <script type="module">
             import Abound from "https://js.withabound.com/latest/abound-client-sdk.js";
+            // debug mode
+            %@
             // Access Token
             const abound = new Abound({
                 accessToken: "%@",

--- a/Sources/Abound/HTMLContent.swift
+++ b/Sources/Abound/HTMLContent.swift
@@ -14,7 +14,7 @@ var taxProfileHTML = """
   <body>
     <div id="abound-ui-wrapper"></div>
     <style>
-      .abound-tax-profile {
+      .abound-w9-collection {
         width: auto;
       }
       input, select{
@@ -30,48 +30,16 @@ var taxProfileHTML = """
       }
     </script>
     <script type="module">
-      import Abound from "https://js.withabound.com/latest/abound-client-sdk.js";
-      // debug mode
-      %@
-      // Access Token
-      const abound = new Abound({
-        accessToken: "%@",
-      });
+      import { renderW9Collection } from "https://js.withabound.com/latest-v2-minor/abound-client-sdk.js";
       // Theme
       %@
       // Custom Content
       %@
-      function onSuccessOrError (){
-                      if(debugMode){
-                          const eins = document.getElementsByName("ein")
-                          if(eins.length>0){
-                              const ein = eins[0].value.replace("-","");
-                              switch(ein){
-                                  case "999999999":
-                                      onError("unverified");
-                                  break;
-                                  case "333333333":
-                                      onError("mismatch");
-                                  break;
-                                  case "111111111":
-                                      onError("error");
-                                  break;
-                                  case "555555555":
-                                      onError("lockedOut");
-                                  break;
-                                  default:
-                                      onSuccess();
-                              }
-                          }
-                      }else{
-                          onSuccess();
-                      }
-                    
-                  }
-      abound.renderTaxProfile({
+      renderW9Collection({
+        accessToken: "%@",
         targetId: "abound-ui-wrapper",
         theme: customTheme,
-        onSubmitSuccess: onSuccessOrError,
+        onSubmitSuccess: onSuccess,
         onSubmitError: onError,
         content: customContent,
       });
@@ -105,19 +73,14 @@ var taxDocumentHTML = """
       }
     </script>
         <script type="module">
-            import Abound from "https://js.withabound.com/latest/abound-client-sdk.js";
-            // debug mode
-            %@
-            // Access Token
-            const abound = new Abound({
-                accessToken: "%@",
-            });
+            import { renderTaxDocuments } from "https://js.withabound.com/latest-v2-minor/abound-client-sdk.js";
             // Theme
             %@
             // Custom Content
             %@
             //Year
-            abound.renderTaxDocuments({
+            renderTaxDocuments({
+               accessToken: "%@",
                year: "%@",
                targetId: "abound-ui-wrapper",
                theme: customTheme,

--- a/Sources/Abound/TaxDocument.swift
+++ b/Sources/Abound/TaxDocument.swift
@@ -14,6 +14,7 @@ public struct TaxDocument: View {
   
     var theme: AboundTheme
     var year: String
+    var debug: Bool
     var onSuccess: (() -> Void)? = nil
     var onError: ((TaxError) -> Void)? = nil
     
@@ -21,12 +22,14 @@ public struct TaxDocument: View {
         theme: AboundTheme = AboundTheme(),
         year: String,
         onSuccess: (() -> Void)? = nil,
-        onError: ((TaxError) -> Void)? = nil
+        onError: ((TaxError) -> Void)? = nil,
+        debug: Bool = false
     ) {
         self.theme = theme
         self.year = year
         self.onSuccess = onSuccess
         self.onError = onError
+        self.debug = debug
     }
     
     @available(iOS 13.0.0, *)
@@ -38,7 +41,8 @@ public struct TaxDocument: View {
             customContent: AboundCustomTextContent(),
             year:year,
             onSuccess:onSuccess,
-            onError:onError
+            onError:onError,
+            debug:debug
         )
     }
 }

--- a/Sources/Abound/TaxDocument.swift
+++ b/Sources/Abound/TaxDocument.swift
@@ -13,7 +13,7 @@ import SwiftUI
 public struct TaxDocument: View {
   
     var theme: AboundTheme
-    private(set) var year: String
+    public private(set) var year: String
     var debug: Bool
     var onSuccess: (() -> Void)? = nil
     var onError: ((TaxError) -> Void)? = nil

--- a/Sources/Abound/TaxDocument.swift
+++ b/Sources/Abound/TaxDocument.swift
@@ -13,7 +13,7 @@ import SwiftUI
 public struct TaxDocument: View {
   
     var theme: AboundTheme
-    var year: String
+    private(set) var year: String
     var debug: Bool
     var onSuccess: (() -> Void)? = nil
     var onError: ((TaxError) -> Void)? = nil

--- a/Sources/Abound/TaxProfile.swift
+++ b/Sources/Abound/TaxProfile.swift
@@ -13,17 +13,20 @@ public struct TaxProfile: View {
     var customContent: AboundCustomTextContent
     var onSuccess: (() -> Void)? = nil
     var onError: ((TaxError) -> Void)? = nil
+    var debug: Bool = false
     
     public init(
         theme: AboundTheme = AboundTheme(),
         customContent: AboundCustomTextContent = AboundCustomTextContent(),
         onSuccess: (() -> Void)? = nil,
-        onError: ((TaxError) -> Void)? = nil
+        onError: ((TaxError) -> Void)? = nil,
+        debug: Bool = false
     ) {
         self.theme = theme
         self.onSuccess = onSuccess
         self.customContent = customContent
         self.onError = onError
+        self.debug = debug
     }
     
     @available(iOS 13.0.0, *)
@@ -35,9 +38,65 @@ public struct TaxProfile: View {
             customContent: customContent,
             year: "2022",
             onSuccess: self.onSuccess,
-            onError: self.onError
+            onError: self.onError,
+            debug:debug
         )
+    }
+}
+
+struct TaxProfileContent: View {
+    @State private var showText = false
+    @State private var errorText = ""
+
+    private var yourBrandsCustomTextContent = AboundCustomTextContent(
+        submitButton:"Submit Button",
+        loadingButton:"Loading Button",
+        loadingPrompt: "Loading Prompt...",
+        errorMessage: "Something went wrong"
+    );
+
+    private var yourBrandsTheme = AboundTheme(
+           text:AboundThemeText(size:"16px"),
+           color: AboundThemeColor(background: "#FFFF00"),
+           shape:AboundThemeShape(componentCornerRadius: "16px"),
+           button: AboundThemeButton(colorActiveBackground: "#655BEF")
+    );
+    private func onSuccess(){
+        self.showText.toggle()
+    }
+    private func onError(taxError: TaxError) -> Void{
+        self.showText.toggle()
+        self.errorText = taxError.error
+    }
+
+    public init(){
+        Abound.accessToken = "accessToken_testeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBfaWQiOiJhcHBJZF90ZXN0NDhlN2VhYTMxNzVhNjYzNTRlMDA2MjY1NDJkMiIsImNyZWF0ZWRfdGltZXN0YW1wIjoxNjU1MDk2NDAwMDAwLCJlbnZpcm9ubWVudCI6Imh0dHBzOi8vc2FuZGJveC1hcGkud2l0aGFib3VuZC5jb20vdjIiLCJleHBpcmF0aW9uX3RpbWVzdGFtcCI6MzI1MDM3MDE2MDAwMDAsInN0YXR1cyI6IkFjdGl2ZSIsInVzZXJfaWQiOiJ1c2VySWRfdGVzdDI0YjA1ZDc2MWZmNThiNTkzMWJkMDc3NzhjNjdiNGU4MThlNCIsImlhdCI6MTY1NTEzMDMxM30.dOUIyxTRV0QDmrFiy-GoyhKc8qru3pymIcPS5cGTaNk"
+    }
+
+
+       var body: some View {
+           VStack {
+               Text(errorText)
+               Text("Tax Profile")
+               if(showText){
+                   Text("Success")
+               }
+               TaxProfile(
+                theme: self.yourBrandsTheme,
+                customContent: self.yourBrandsCustomTextContent,
+                onSuccess: self.onSuccess,
+                onError: self.onError,
+                debug:true
+               )
+           }
+       }
+}
+struct TaxProfileContent_Preview : PreviewProvider {
+
+    @State static var value = false
+
+    static var previews: some View {
+        TaxProfileContent()
     }
 
 }
-

--- a/Sources/Abound/TaxProfile.swift
+++ b/Sources/Abound/TaxProfile.swift
@@ -36,7 +36,7 @@ public struct TaxProfile: View {
             accessToken: Abound.accessToken,
             theme: theme,
             customContent: customContent,
-            year: "2022",
+            year: "",
             onSuccess: self.onSuccess,
             onError: self.onError,
             debug:debug
@@ -70,7 +70,7 @@ struct TaxProfileContent: View {
     }
 
     public init(){
-        Abound.accessToken = "accessToken_testeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBfaWQiOiJhcHBJZF90ZXN0NDhlN2VhYTMxNzVhNjYzNTRlMDA2MjY1NDJkMiIsImNyZWF0ZWRfdGltZXN0YW1wIjoxNjU1MDk2NDAwMDAwLCJlbnZpcm9ubWVudCI6Imh0dHBzOi8vc2FuZGJveC1hcGkud2l0aGFib3VuZC5jb20vdjIiLCJleHBpcmF0aW9uX3RpbWVzdGFtcCI6MzI1MDM3MDE2MDAwMDAsInN0YXR1cyI6IkFjdGl2ZSIsInVzZXJfaWQiOiJ1c2VySWRfdGVzdDI0YjA1ZDc2MWZmNThiNTkzMWJkMDc3NzhjNjdiNGU4MThlNCIsImlhdCI6MTY1NTEzMDMxM30.dOUIyxTRV0QDmrFiy-GoyhKc8qru3pymIcPS5cGTaNk"
+        Abound.accessToken = "accessToken_sampleeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTY5ODczNTcsImV4cCI6MTY5Njk4NzY1NywiYXVkIjoiYXBwSWRfc2FtcGxlcU5oVmNkWVFZVSIsImlzcyI6Imh0dHBzOi8vc2FuZGJveC1hcGkud2l0aGFib3VuZC5jb20vdjQiLCJzdWIiOiJ1c2VySWRfc2FtcGxlWEdNRm5oT3BlUiJ9.-NrPVQvsnM8vJouyuP5yeFGlYb1xGgR-gS3v87p5BQk"
     }
 
 

--- a/Sources/Abound/WebView.swift
+++ b/Sources/Abound/WebView.swift
@@ -91,12 +91,10 @@ struct WebView: UIViewRepresentable {
     }
     
     private func getHTML() -> String{
-        let debugMode = debug ?  "const debugMode  = true": "const debugMode  = false"
-        
         if currentType == DocumentType.taxDocument{
-            return String(format: taxDocumentHTML, arguments: [debugMode,accessToken,theme.toHtml(),customContent.toHtml(),year])
+            return String(format: taxDocumentHTML, arguments: [theme.toHtml(),customContent.toHtml(),accessToken,year])
         }else{
-            return String(format: taxProfileHTML, arguments: [debugMode,accessToken,theme.toHtml(),customContent.toHtml(),year])
+            return String(format: taxProfileHTML, arguments: [theme.toHtml(),customContent.toHtml(),accessToken])
         }
     }
     

--- a/Sources/Abound/WebView.swift
+++ b/Sources/Abound/WebView.swift
@@ -17,7 +17,7 @@ struct WebView: UIViewRepresentable{
     var year: String
     var onSuccess: (() -> Void)? = nil
     var onError: ((TaxError) -> Void)? = nil
-    
+    var debug: Bool
   
     func makeUIView(context: Context) -> WKWebView {
         let onCallbackHandler = WebViewCallbacks(onSuccess: self.onSuccess, onError: self.onError)
@@ -30,10 +30,12 @@ struct WebView: UIViewRepresentable{
     }
     
     func getHTML() -> String{
+        let debugMode = debug ?  "const debugMode  = true": "const debugMode  = false"
+        
         if currentType == DocumentType.taxDocument{
-            return String(format: taxDocumentHTML, arguments: [accessToken,theme.toHtml(),customContent.toHtml(),year])
+            return String(format: taxDocumentHTML, arguments: [debugMode,accessToken,theme.toHtml(),customContent.toHtml(),year])
         }else{
-            return String(format: taxProfileHTML, arguments: [accessToken,theme.toHtml(),customContent.toHtml(),year])
+            return String(format: taxProfileHTML, arguments: [debugMode,accessToken,theme.toHtml(),customContent.toHtml(),year])
         }
     }
     


### PR DESCRIPTION
Updated `TaxDocument.year` to be publicly readable. This aids in creating automated tests around `TaxDocument`. For us, this allows us to assert that `TaxDocument` was created with the expected year.

Updated `WebView` to delegate any links that were clicked to be opened by the system. This allows tapping on a link to a document shown in a `TaxDocument` to be opened in Safari. Without this update, tapping on a link to a tax document shown in `TaxDocument` doesn't result in a user seeing the document. The only way to view the document is to long-press the link and then choose to open the URL in Safari. Perhaps I missed something when using the `TaxDocument` element and this isn't a necessary change. If so, please let me know.

Implemented `WebView.updateUIView`. This allows `WebView` and therefore `TaxDocument` and `TaxProfile` to respond to any state changes in SwiftUI. This results in the `WebView` contents being loaded again with any state changes. We used this to update a `TaxDocument` instance based on a year selected from a drop-down. The screen shows a drop-down asking the user to choose a year with a `TaxDocument` instance below the drop-down. When the users choose a different year, the `TaxDocument` is reloaded to pull in the documents for the newly selected year.